### PR TITLE
Define _STAT_VER if not already defined

### DIFF
--- a/nwuser/code.h
+++ b/nwuser/code.h
@@ -76,4 +76,18 @@ extern char	*__nwu_basedir;
 
 #endif
 
-
+#ifndef _STAT_VER
+ #if defined (__aarch64__)
+  #define _STAT_VER 0
+ #elif defined (__powerpc__) && __WORDSIZE == 64
+  #define _STAT_VER 1
+ #elif defined (__riscv) && __riscv_xlen==64
+  #define _STAT_VER 0
+ #elif defined (__s390x__)
+  #define _STAT_VER 1
+ #elif defined (__x86_64__)
+  #define _STAT_VER 1
+ #else
+  #define _STAT_VER 3
+ #endif
+#endif


### PR DESCRIPTION
_STAT_VER is no longer declared in glibc 2.33. I'm not a C-developer, I just copied the code from fakeroot repo:
https://salsa.debian.org/clint/fakeroot/-/blob/57731fb5071b86d70d5a3e207addaabdde23111e/libfakeroot.c#L93-107

Patch works successfully on my Arch Linux x86-64.